### PR TITLE
Menu updates for Resources & Community Activities

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -35,7 +35,10 @@ sidebar:
   - title: Code Of Conduct
     url: CodeOfConduct/codeofconduct
   - title: Resources
-    # url: /TechTalk/2020/
+    # url: /Resources/
+    children:
+      - title: "The C++ Standard"
+      # url: /CppStandard/
   - title: Community Activities
     children:
       - title: "Tech-Talks"

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -36,13 +36,20 @@ sidebar:
     url: CodeOfConduct/codeofconduct
   - title: Resources
     # url: /TechTalk/2020/
+  - title: Community Activities
     children:
+      - title: "Tech-Talks"
+        children:
+          - title: "2021"
+          url: /TechTalk/2021/
+          - title: "2020"
+          url: /TechTalk/2020/
+      - title: "Royal Code Roast"
+      # url: /RoyalCodeRoast/
+      - title: "Community Fireside Chat"
+      # url: /CommunityFiresideChat/
       - title: Session Schedule
         url: /TechTalk/schedule/
-      - title: "Tech-Talks 2021"
-        url: /TechTalk/2021/
-      - title: "Tech-Talks 2020"
-        url: /TechTalk/2020/
   - title: Call For Speakers
     url: /callforspeakers/call_for_speakers/
   - title: Sponsors


### PR DESCRIPTION
Left hand side menu should now look like below. New pages are not yet added. Only existing 2021 & 2020 talk pages linked. Others to be created. 
Resources
- The C++ Standard
Community Activities
- Tech-Talks
  - 2021
  - 2020
- Royal Code Roast
- Community Fireside Chat